### PR TITLE
brass tacks

### DIFF
--- a/src/main/java/io/github/ititus/downfallRelicStats/DownfallRelicStats.java
+++ b/src/main/java/io/github/ititus/downfallRelicStats/DownfallRelicStats.java
@@ -56,6 +56,7 @@ public final class DownfallRelicStats implements EditStringsSubscriber, PostInit
         register(BarbellsInfo.getInstance()); // Barbell
         register(AbsorbEndCombatUpgradedInfo.getInstance()); // Black Heart of Goo
         register(BlackPowderInfo.getInstance()); // Black Powder
+        register(BrassTacksInfo.getInstance()); // Brass Tacks
         register(BloodyToothInfo.getInstance()); // Broken Tooth
         register(BronzeCoreInfo.getInstance()); // Bronze Core
         register(ModeShifterInfo.getInstance()); // Bronze Gear

--- a/src/main/java/io/github/ititus/downfallRelicStats/patches/relics/BrassTacksInfo.java
+++ b/src/main/java/io/github/ititus/downfallRelicStats/patches/relics/BrassTacksInfo.java
@@ -1,0 +1,33 @@
+package io.github.ititus.downfallRelicStats.patches.relics;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.powers.MetallicizePower;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import hermit.relics.BrassTacks;
+import io.github.ititus.downfallRelicStats.BaseCombatRelicStats;
+
+public final class BrassTacksInfo extends BaseCombatRelicStats {
+    private static final BrassTacksInfo INSTANCE = new BrassTacksInfo();
+    private static final int BRASS_TACKS_DEFAULT_BLOCK_AMOUNT = 2;
+
+    private BrassTacksInfo() {
+        super(BrassTacks.ID);
+        this.showPerTurn = false;
+    }
+
+    public static BrassTacksInfo getInstance() {
+        return INSTANCE;
+    }
+
+    @SpirePatch(
+        clz = MetallicizePower.class,
+        method = "atEndOfTurnPreEndTurnCards"
+    )
+    @SuppressWarnings("unused")
+    public static class Patch {
+        public static void Postfix() {
+            if (AbstractDungeon.player.hasRelic(BrassTacks.ID))
+                getInstance().increaseAmount(BRASS_TACKS_DEFAULT_BLOCK_AMOUNT);
+        }
+    }
+}

--- a/src/main/resources/downfallRelicStatsResources/localization/eng/descriptions.json
+++ b/src/main/resources/downfallRelicStatsResources/localization/eng/descriptions.json
@@ -200,6 +200,11 @@
       " NL In Act %d: "
     ]
   },
+  "STATS:hermit:BrassTacks": {
+    "TEXT": [
+      "Block gained: "
+    ]
+  },
   "STATS:hermit:CharredGlove": {
     "TEXT": [
       "Vigor gained: "


### PR DESCRIPTION
the reason thread and needle is difficult to track is because the amount of plated armor you have can go up and down, so its difficult to know if block came from thread and needle or wish or essence of steel.

but metallicize never goes down, youll keep that 2 metallicize forever. brass tacks is simply 2 block per turn.